### PR TITLE
pairing game rooms, status codes

### DIFF
--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -30,7 +30,7 @@ const statusEnum = {
 const numToState = new Map<number, string>([
     [-1, "Error, likely caused by duplicate logins"],
     [0, "Disconnected from server"],
-    [1, "Connected to server"],
+    [1, "Connected to server, but not logged in"],
     [2, "Authenticated by server"],
     [3, "Waiting for opponent"],
     [4, "Paired with opponent"],

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -27,7 +27,7 @@ const statusEnum = {
 }
 
 // ! stupid solution, please help
-const numToState = new Map<number, string>([
+const statusNumToDescription = new Map<number, string>([
     [-1, "Error, likely caused by duplicate logins"],
     [0, "Disconnected from server"],
     [1, "Connected to server, but not logged in"],
@@ -123,7 +123,7 @@ const ChatRoom: React.FunctionComponent = ()  => {
                     sendMessage({
                         type: "upgrade status",
                         payload: {
-                            name: "pairing",
+                            name: "joinRoom",
                             userID: "",
                             data: "",
                         }
@@ -184,7 +184,7 @@ const ChatRoom: React.FunctionComponent = ()  => {
             })}
             </MessageListColumn>
         </>
-        : <StatusText>Status: {numToState.get(status)}</StatusText> 
+        : <StatusText>Status: {statusNumToDescription.get(status)}</StatusText> 
         }
       <PlayButton to="/">MAIN</PlayButton>
       </RightSideContent>

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -1,15 +1,10 @@
-import { SetStateAction, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { SetStateAction, useState } from "react";
 import {useUser} from "../context/UserContext";
-import {UserType} from "../types/UserType"
 import {MessageType, PayloadType} from "../types/MessageType"
 import styled from "styled-components";
 import ViewWrapper from "./common/ViewWrapper";
 import { PageContainer, PlayButton, RightSideContent, TitleText } from "./pages/index/IndexView";
 import Payload from "./Payload";
-
-// import sendMessage from "../components/common/ws"
-
 
 const ws: WebSocket = new WebSocket('ws://localhost:4000')
 
@@ -21,25 +16,60 @@ const sendMessage = (message: MessageType) => {
     ws.send(JSON.stringify(message));
 }
 
+// * According to level, the larger the better
+const statusEnum = {
+    Stop: -1,
+    Disconnected: 0,
+    Connected: 1,
+    Authenticated: 2,
+    InQueue: 3,
+    Paired: 4,
+}
+
+// ! stupid solution, please help
+const numToState = new Map<number, string>([
+    [-1, "Error, likely caused by duplicate logins"],
+    [0, "Disconnected from server"],
+    [1, "Connected to server"],
+    [2, "Authenticated by server"],
+    [3, "Waiting for opponent"],
+    [4, "Paired with opponent"],
+]);
+
+
+
 const ChatRoom: React.FunctionComponent = ()  => {
   const [user, updateUser, fetchUser] = useUser()
+  const [inputText, setInputText] = useState<string>('');
+  const [status, setStatus] = useState<number>(statusEnum.Connected);
+  const [messages, setMessages] = useState<PayloadType[]>([])
+
   if (user && user.loggedIn) {
-    if (user?.socketStatus != "connected & authenticated") {
+    if (status === statusEnum.Connected) {
         sendMessage({
-            type: "authentication",
+            type: "upgrade status",
             payload: {
-            name: "",
-            userID: "",
-            data: user.jwtCredential,
+                name: "authentication",
+                userID: "",
+                data: user.jwtCredential,
             }
         })
     }
-}
-  const [inputText, setInputText] = useState<string>('');
-
-  const [status, setStatus] = useState<string>('noAuth');
-
-  const [messages, setMessages] = useState<PayloadType[]>([])
+    /**
+     * * This doesn't necessary need to be automatic, like in the future there might be options
+     * * to join different games and stuff. But for now it will be automatic
+     */
+    // if (status === statusEnum.Authenticated) {
+    //     sendMessage({
+    //         type: "upgrade status",
+    //         payload: {
+    //             name: "pairing",
+    //             userID: "",
+    //             data: "",
+    //         }
+    //     })
+    // }
+  }
   
   const handleInputChange = (event: { target: { value: SetStateAction<string>; }; }) => {
     setInputText(event.target.value);
@@ -47,38 +77,60 @@ const ChatRoom: React.FunctionComponent = ()  => {
 
   ws.onmessage = (byteString) => {
     const {type, payload} = JSON.parse(byteString.data);
-    // console.log("received Message: ", type, payload)
     switch (type) {
         case "chat":
-            // console.log(payload.name, "said", payload.data)
             setMessages(messages => {
                 const newmessage: PayloadType[] = [...messages, payload]
-                // console.log(newmessage)
                 return newmessage
             });
             break;
-        case "authentication":
-            console.log("Being requested Auth")
+        case "status":
             if (!user) throw new Error("User undefined.")
             if (!user.loggedIn) throw new Error("User not logged in.")
-            if (payload.name == "request") {
+            if (payload.name === "authentication request") {
                 sendMessage({
-                    type: "authentication",
+                    type: "upgrade status",
                     payload: {
-                      name: "",
+                      name: "authentication",
                       userID: "",
                       data: user.jwtCredential,
                     }
                 })
-            } else if (payload.name == "result") {
-                if (payload.data == "success") {
-                    console.log("Authentication Succeeded")
-                    updateUser!((user: UserType) => {
-                        user.socketStatus = "connected & authenticated";
-                        return user;
+            } else if (payload.name === "status update") {
+                if (payload.data === "paired") {
+                    console.log("Pairing Succeeded")
+                    setStatus(status => {
+                        if (status <= 3) return statusEnum.Paired
+                        return status
                     })
-                } else if (payload.data == "retry") {
-                    console.log("Authentication Failed, retrying")
+                } else if (payload.data === "in queue") {
+                    console.log("Waiting in queue")
+                    setStatus(status => {
+                        if (status <= 2) return statusEnum.InQueue
+                        return status
+                    })
+                } else if (payload.data === "authenticated") {
+                    console.log("Authentication Succeeded")
+                    setStatus(status => {
+                        if (status <= 1) return statusEnum.Authenticated
+                        return status
+                    })
+
+                    /**
+                     * * This doesn't necessary need to be automatic, like in the future there might be options
+                     * * to join different games and stuff. But for now it will be automatic
+                     */
+                    sendMessage({
+                        type: "upgrade status",
+                        payload: {
+                            name: "pairing",
+                            userID: "",
+                            data: "",
+                        }
+                    })
+                } else if (payload.data === "connected") {
+                    console.log("Authentication failed, retrying")
+
                     sendMessage({
                         type: "authentication",
                         payload: {
@@ -88,7 +140,8 @@ const ChatRoom: React.FunctionComponent = ()  => {
                         }
                     })
                 } else {
-                    console.log("Authentication Failed.")
+                    console.log("Irregular authentication failure from", payload.data)
+                    setStatus(status => -1)
                 }
             } else {
                 throw new Error("Unknown message")
@@ -112,19 +165,27 @@ const ChatRoom: React.FunctionComponent = ()  => {
   };
 
 
+
+  /**
+   * TODO make it automatically align to bottom of messages
+   */
   return (
     <ViewWrapper> {/** holds animation and container logic*/}
     <PageContainer>
       <RightSideContent>
-        <TitleText>mfChess</TitleText>
-        
-        <input type="text" value={inputText} onChange={handleInputChange} />
-        <button onClick={handleButtonClick}> send </button>
-        <MessageListColumn>
-        {messages.map((payload, idx) => {
-            return <Payload key={idx} payload={payload}></Payload>
-        })}
-        </MessageListColumn>
+        <TitleText>ChatRoom</TitleText>
+        {status === statusEnum.Paired ? 
+        <>
+            <input type="text" value={inputText} onChange={handleInputChange} />
+            <button onClick={handleButtonClick}> send </button>
+            <MessageListColumn>
+            {messages.map((payload, idx) => {
+                return <Payload key={idx} payload={payload}></Payload>
+            })}
+            </MessageListColumn>
+        </>
+        : <StatusText>Status: {numToState.get(status)}</StatusText> 
+        }
       <PlayButton to="/">MAIN</PlayButton>
       </RightSideContent>
     </PageContainer>
@@ -134,6 +195,13 @@ const ChatRoom: React.FunctionComponent = ()  => {
 
 export default ChatRoom;
 
+export const StatusText = styled.h1`
+  color: #EFC050;
+  font-size: 2em;
+  font-weight: 800;
+  margin: 0;
+`;
+
 const MessageListColumn = styled.div`
   overflow: auto;
   padding-top: 3rem;
@@ -142,5 +210,4 @@ const MessageListColumn = styled.div`
   border: 1px solid #dee2e6;
   height: 200px;
   width: 500px;
-  absolute: bottom;
 `

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -20,13 +20,11 @@ const Login: React.FunctionComponent = ()  => {
    */
   const handleCredentialResponse = (response: { credential: string; }) => {
     const credential: string  = response.credential
-    console.log("Logged in:", credential)
     AxiosInstance({
       method: 'post',
       url: "login",
       data: {token: credential},
     }).then((response) => {
-      console.log(response.data);
       updateUser!((user: UserType) => {
         user.loggedIn = true;
         user.userID = response.data.sub

--- a/src/components/MessageTemplate.txt
+++ b/src/components/MessageTemplate.txt
@@ -1,0 +1,64 @@
+Client to Server
+    Upgrading Status
+        {
+            type: "upgrade status",
+            payload: {
+            name: "authentication"
+            userID: "",
+            data: user.jwtCredential,
+            }
+        }
+
+        {
+            type: "upgrade status",
+            payload: {
+            name: "pairing"
+            userID: "",
+            data: "",
+            }
+        }
+    chat
+        {
+            type: "chat",
+            payload: {
+            name: user.name,
+            userID: user.userID,
+            data: inputText,
+            }
+        }
+Server to Client
+    status
+        authentication request
+            {
+                type: "status",
+                payload: {
+                    name: "authentication request",
+                    userID: "",
+                    data: "",
+                }
+            }
+    status update
+        {
+            type: "status",
+            payload: {
+                name: "status update",
+                userID: "",
+                data: "authenticated",
+            }
+        }
+        {
+            type: "status",
+            payload: {
+                name: "status update",
+                userID: "",
+                data: "in queue",
+            }
+        }
+        {
+            type: "status",
+            payload: {
+                name: "status update",
+                userID: "",
+                data: "connected",
+            }
+        }

--- a/src/components/MessageTemplate.txt
+++ b/src/components/MessageTemplate.txt
@@ -12,7 +12,7 @@ Client to Server
         {
             type: "upgrade status",
             payload: {
-            name: "pairing"
+            name: "joinRoom"
             userID: "",
             data: "",
             }

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -6,6 +6,29 @@ interface Props {
     isMe: boolean;
 }
 
+type FCProps = {
+    payload: PayloadType;
+};
+
+/**
+ * * FC for payload used in chatroom
+ * TODO make it look better
+ * @param param0 
+ */
+const Payload = ({payload}:FCProps):JSX.Element => {
+    const [user, updateUser, fetchUser] = useUser()
+
+    // console.log(payload.userID, user!.userID)
+    const isMe: boolean = payload.userID === user!.userID;
+    return (
+        <StyledMessage isMe={isMe}>
+            {isMe ? <p>{payload.data}</p> : <p>{payload.name}: {payload.data}</p>}
+        </StyledMessage>
+    );
+};
+
+export default Payload;
+
 const StyledMessage = styled.div<Props>`
     display: flex;
     align-items: center;
@@ -24,21 +47,3 @@ const StyledMessage = styled.div<Props>`
         margin: auto 0;
     }
 `;
-
-type FCProps = {
-    payload: PayloadType;
-};
-
-const Payload = ({payload}:FCProps):JSX.Element => {
-    const [user, updateUser, fetchUser] = useUser()
-
-    // console.log(payload.userID, user!.userID)
-    const isMe: boolean = payload.userID === user!.userID;
-    return (
-        <StyledMessage isMe={isMe}>
-            {isMe ? <p>{payload.data}</p> : <p>{payload.name}: {payload.data}</p>}
-        </StyledMessage>
-    );
-};
-
-export default Payload;

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -30,8 +30,6 @@ export const defaultUser = () => {
             userID: "",
             jwtCredential: "",
 
-            socketStatus: "not connected",
-
             name: "",
             email: "",
             profilePictureUrl: "",

--- a/src/types/MessageType.ts
+++ b/src/types/MessageType.ts
@@ -1,5 +1,5 @@
 /**
- * * Message Type for sockets
+ * * Message Types for sockets
  * ! To be extended
  */
 export interface PayloadType {

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -7,8 +7,6 @@ export interface UserType {
     userID: string;
     jwtCredential: string;
 
-    socketStatus: string;
-
     name: string;
     email: string;
     profilePictureUrl: string;


### PR DESCRIPTION
Finally solves #7 

Player can login, then go to chatroom, and wait till it gets pair with another user. Upon pairing, they can have a private chat (or game of chess)

- MessageTemplate.txt is a temporary solution for the ugly message structure.
- Status Enums and numToState for status
- changed the status field to be a useState of ChatRoom instead of the UserContext

Still some problems (frontend):
- need a way to check if the rooms and players are alive, probably with a neverending timeout loop that kicks those that are dead (or not)
- come up with a way to nicely define the message sent using sockets.
- Displaying is not the best (I tried), such as the senders name using same form as the message.
- will do comments and better structure later!